### PR TITLE
Replace minimatch with path.matchesGlob

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "@actions/exec": "3.0.0",
     "@octokit/action": "8.0.4",
     "@octokit/plugin-retry": "8.1.0",
-    "graphql": "16.14.1",
-    "minimatch": "10.2.5"
+    "graphql": "16.14.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       graphql:
         specifier: 16.14.1
         version: 16.14.1
-      minimatch:
-        specifier: 10.2.5
-        version: 10.2.5
     devDependencies:
       '@biomejs/biome':
         specifier: 2.4.16

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -89,6 +89,7 @@ const createGlobMatcher =
     if (patterns.length === 0) {
       return defaultValue
     }
+    // The patterns must contain at least one positive pattern, otherwise the negation patterns will be ignored.
     let matched = false
     for (const pattern of patterns) {
       if (pattern.startsWith('!')) {

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
-import * as minimatch from 'minimatch'
 import type { ListChecksQuery } from './generated/graphql.js'
 import { CheckConclusionState, CheckStatusState } from './generated/graphql-types.js'
+import { matchesGlob } from 'node:path'
 
 export type Rollup = {
   status: RollupStatus
@@ -53,8 +53,8 @@ export const rollupChecks = (checks: ListChecksQuery, options: RollupOptions): R
 
   const latestWorkflowRuns = filterLatestWorkflowRuns(rawWorkflowRuns)
 
-  const excludeWorkflowNameMatchers = options.excludeWorkflowNames.map((pattern) => minimatch.filter(pattern))
-  const filterWorkflowNameMatchers = options.filterWorkflowNames.map((pattern) => minimatch.filter(pattern))
+  const excludeWorkflowNameMatcher = createGlobMatcher(options.excludeWorkflowNames, false)
+  const filterWorkflowNameMatcher = createGlobMatcher(options.filterWorkflowNames)
   const workflowRuns = latestWorkflowRuns.filter((workflowRun) => {
     // Exclude self to prevent the infinite loop
     if (workflowRun.workflowName === options.selfWorkflowName) {
@@ -67,18 +67,11 @@ export const rollupChecks = (checks: ListChecksQuery, options: RollupOptions): R
       }
     }
     // Exclude workflows by names
-    if (excludeWorkflowNameMatchers.length > 0) {
-      if (excludeWorkflowNameMatchers.some((match) => match(workflowRun.workflowName))) {
-        return false
-      }
+    if (excludeWorkflowNameMatcher(workflowRun.workflowName)) {
+      return false
     }
     // Filter workflows by names
-    if (filterWorkflowNameMatchers.length > 0) {
-      if (!filterWorkflowNameMatchers.some((match) => match(workflowRun.workflowName))) {
-        return false
-      }
-    }
-    return true
+    return filterWorkflowNameMatcher(workflowRun.workflowName)
   })
 
   sortByWorkflowName(workflowRuns)
@@ -89,6 +82,23 @@ export const rollupChecks = (checks: ListChecksQuery, options: RollupOptions): R
     workflowRuns,
   }
 }
+
+const createGlobMatcher =
+  (patterns: string[], defaultValue = true) =>
+  (target: string): boolean => {
+    if (patterns.length === 0) {
+      return defaultValue
+    }
+    let matched = false
+    for (const pattern of patterns) {
+      if (pattern.startsWith('!')) {
+        matched = matched && !matchesGlob(target, pattern.slice(1))
+      } else {
+        matched = matched || matchesGlob(target, pattern)
+      }
+    }
+    return matched
+  }
 
 export const filterLatestWorkflowRuns = (workflowRuns: WorkflowRun[]): WorkflowRun[] => {
   const latestWorkflowRuns = new Map<string, WorkflowRun>()

--- a/src/checks.ts
+++ b/src/checks.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
+import { matchesGlob } from 'node:path'
 import type { ListChecksQuery } from './generated/graphql.js'
 import { CheckConclusionState, CheckStatusState } from './generated/graphql-types.js'
-import { matchesGlob } from 'node:path'
 
 export type Rollup = {
   status: RollupStatus


### PR DESCRIPTION
Node.js 24 ships `path.matchesGlob` natively, making the `minimatch` dependency redundant.
